### PR TITLE
Fixed invalid reference to global "loveframes" in demo.lua

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,7 +1,7 @@
 function love.load()
 	
 	tween = require("libraries.third-party.tween")
-	require("libraries.loveframes")
+	loveframes = require("libraries.loveframes")
 	require("libraries.demo")
 	
 	bgimage = love.graphics.newImage("resources/images/bg.png")


### PR DESCRIPTION
libraries.demo wouldn't be able to reference loveframes if it weren't defined and loveframes no longer declares itself in the global scope.